### PR TITLE
Use ES6 to further shave bytes

### DIFF
--- a/mmd.js
+++ b/mmd.js
@@ -1,1 +1,1 @@
-function define(a,b,c){define[a]=require(c?b:[],c||b)}function require(a,b,c,i){c=[];for(i in a)c[i]=define[a[i]];return b.apply(0,c)}
+define=(a,b,c)=>{define[a]=require(c?b:[],c||b)},require=(a,b)=>b(...a.map(c=>define[c]));


### PR DESCRIPTION
Just because we can: using ES6 gives us AMD in 90 characters :octopus: 

Runs in latest  Chrome an Firefox and should probably never be used.
